### PR TITLE
API state endpoint

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,16 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.kuadrant.io
   resources:
   - apis

--- a/pkg/interfaces/controllers/api_controller.go
+++ b/pkg/interfaces/controllers/api_controller.go
@@ -48,6 +48,7 @@ const cMPayload = "payload"
 //+kubebuilder:rbac:groups=networking.kuadrant.io,resources=apis,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.kuadrant.io,resources=apis/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=networking.kuadrant.io,resources=apis/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/pkg/interfaces/http/handlers/api_handler.go
+++ b/pkg/interfaces/http/handlers/api_handler.go
@@ -11,6 +11,8 @@ import (
 type APIHandler interface {
 	Get(*gin.Context)
 	List(*gin.Context)
+	GetListState(*gin.Context)
+	UpdateListState(*gin.Context)
 }
 
 type apiHandler struct {
@@ -55,4 +57,31 @@ func (h *apiHandler) List(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, list)
+}
+
+func (h *apiHandler) GetListState(ctx *gin.Context) {
+	apiListState, err := h.service.GetAPIListState(ctx)
+
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, apiListState)
+}
+
+func (h *apiHandler) UpdateListState(ctx *gin.Context) {
+	hash := ctx.Param("hash")
+	if len(hash) == 0 { // this check might be a candidate to extract and reuse
+		ctx.JSON(http.StatusBadRequest, "Missing param `hash`")
+		return
+	}
+	err := h.service.UpdateAPIListState(ctx, hash)
+
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, err)
+		return
+	}
+
+	ctx.JSON(http.StatusNoContent, "API List State updated successfully")
 }

--- a/pkg/interfaces/http/router.go
+++ b/pkg/interfaces/http/router.go
@@ -20,6 +20,8 @@ func urlMappings() {
 	router.GET("/ping", handlers.Ping)
 	router.GET("/apis", apiHandler.List)
 	router.GET("/apis/:name", apiHandler.Get)
+	router.GET("/state", apiHandler.GetListState)
+	router.PUT("/state/:hash", apiHandler.UpdateListState)
 }
 
 func Start() {

--- a/pkg/services/api/service.go
+++ b/pkg/services/api/service.go
@@ -11,6 +11,8 @@ import (
 type Service interface {
 	GetAPI(context.Context, string) (*api.API, error)
 	ListAPI(context.Context) (*api.APIs, error)
+	GetAPIListState(context.Context) (string, error)
+	UpdateAPIListState(context.Context, string) error
 }
 
 type service struct {
@@ -41,4 +43,20 @@ func (s *service) ListAPI(ctx context.Context) (*api.APIs, error) {
 		return nil, err
 	}
 	return apis, nil
+}
+
+func (s *service) GetAPIListState(ctx context.Context) (string, error) {
+	apiListState, err := s.kuadrantRepo.GetAPIListState(ctx)
+	if err != nil {
+		return "", err
+	}
+	return apiListState, nil
+}
+
+func (s *service) UpdateAPIListState(ctx context.Context, hash string) error {
+	apisHash := strings.TrimSpace(hash)
+	if len(apisHash) == 0 {
+		return fmt.Errorf("invalid hash")
+	}
+	return s.kuadrantRepo.UpdateAPIListState(ctx, apisHash)
 }


### PR DESCRIPTION
In order to Kamrad communicate and share it's state with Kamwiel, the latter needs to provide an endpoint for such action. This PR introduces said endpoint.

One could get the API List State like the following:

```bash
curl -H 'X-API-KEY: YOUR_API_KEY' http://kamwiel-authorino.127.0.0.1.nip.io:8000/state
```

And update it's "freshness" passing the API List hash like:

```bash
curl -X PUT -H 'X-API-KEY: YOUR_API_KEY' http://kamwiel-authorino.127.0.0.1.nip.io:8000/state/th1s1s4h4sh
```
This will compare the state passed with Kamwiel local's one, if it's the same, it will update the ConfigMap (`kamwiel-api-list-state`) data `fresh`=> `false`. Meaning Kamrad is communicating it successfully build and deploy that md5 hash.